### PR TITLE
added towardsdatascience since it has the same styling as medium

### DIFF
--- a/script/app.js
+++ b/script/app.js
@@ -6,6 +6,7 @@
 // @author       jlhg
 // @match        https://medium.com/@*
 // @match        https://*.medium.com/*
+// @match        https://towardsdatascience.com/*
 // ==/UserScript==
 
 (function() {


### PR DESCRIPTION
https://towardsdatascience.com/ is a sub page/brand of medium so it has the same message, but it is under a different domain.  I have included this domain in the @match so that it is also included in supressing the nag message.